### PR TITLE
Run GitHub Action build on Pull Request also

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   Build:


### PR DESCRIPTION
So you would be able to see the GitHub Action running on this pull request, but not currently on any other because to run GitHub Actions on PRs, one needs to specify the same in the GitHub Action